### PR TITLE
Refactor API routes with validation

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,115 +1,12 @@
 import express from 'express';
-import { PrismaClient } from '@prisma/client';
-
-interface Book {
-  id: string;
-  title: string;
-  authors: string[];
-  [key: string]: any;
-}
+import booksRouter from './routes/books';
+import googleBooksRouter from './routes/google-books';
 
 const app = express();
 app.use(express.json());
 
-const gbCache = new Map<string, { ts: number; data: any }>();
-const CACHE_MS = 1000 * 60 * 60; // 1 hour
-
-const prisma = new PrismaClient();
-
-function formatBook(book: any): Book {
-  return {
-    id: book.id,
-    title: book.title,
-    authors: book.authors.map((a: any) => a.name),
-  };
-}
-
-app.post('/api/books', async (req, res) => {
-  try {
-    const book: Book = req.body;
-    const created = await prisma.book.create({
-      data: {
-        id: book.id,
-        title: book.title,
-        authors: {
-          connectOrCreate: book.authors.map((name) => ({
-            where: { name },
-            create: { name },
-          })),
-        },
-      },
-      include: { authors: true },
-    });
-    res.status(201).json(formatBook(created));
-  } catch {
-    res.status(500).json({ error: 'Failed to add book' });
-  }
-});
-
-app.get('/api/books', async (_req, res) => {
-  try {
-    const books = await prisma.book.findMany({ include: { authors: true } });
-    res.json(books.map(formatBook));
-  } catch {
-    res.status(500).json({ error: 'Failed to read books' });
-  }
-});
-
-app.put('/api/books/:id', async (req, res) => {
-  const { id } = req.params;
-  const book: Book = req.body;
-  try {
-    const updated = await prisma.book.update({
-      where: { id },
-      data: {
-        title: book.title,
-        authors: {
-          set: [],
-          connectOrCreate: book.authors.map((name) => ({
-            where: { name },
-            create: { name },
-          })),
-        },
-      },
-      include: { authors: true },
-    });
-    res.json(formatBook(updated));
-  } catch {
-    res.status(500).json({ error: 'Failed to update book' });
-  }
-});
-
-app.delete('/api/books/:id', async (req, res) => {
-  const { id } = req.params;
-  try {
-    const removed = await prisma.book.delete({
-      where: { id },
-      include: { authors: true },
-    });
-    res.json(formatBook(removed));
-  } catch {
-    res.status(500).json({ error: 'Failed to delete book' });
-  }
-});
-
-app.get('/api/google-books', async (req, res) => {
-  const q = String(req.query.q ?? '').trim();
-  if (!q) return res.status(400).json({});
-  const cached = gbCache.get(q);
-  if (cached && Date.now() - cached.ts < CACHE_MS) {
-    return res.json(cached.data);
-  }
-  const url = new URL('https://www.googleapis.com/books/v1/volumes');
-  url.searchParams.set('q', q);
-  url.searchParams.set('maxResults', '20');
-  const key = process.env.GOOGLE_BOOKS_KEY;
-  if (key) url.searchParams.set('key', key);
-  const r = await fetch(url);
-  if (!r.ok) return res.status(500).end();
-  const data = await r.json();
-  gbCache.set(q, { ts: Date.now(), data });
-  res.json(data);
-});
+app.use('/api/v1/books', booksRouter);
+app.use('/api/v1/google-books', googleBooksRouter);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/server/routes/books.ts
+++ b/server/routes/books.ts
@@ -1,0 +1,132 @@
+import { Router } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { BookSchema, BookIdSchema, type Book } from '../schemas';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+function formatBook(book: any): Book {
+  return {
+    id: book.id,
+    title: book.title,
+    authors: book.authors.map((a: any) => a.name),
+  };
+}
+
+router.post('/', async (req, res) => {
+  const parse = BookSchema.safeParse(req.body);
+  if (!parse.success) {
+    return res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'Invalid book',
+      details: parse.error.flatten(),
+    });
+  }
+  const book = parse.data;
+  try {
+    const created = await prisma.book.create({
+      data: {
+        id: book.id,
+        title: book.title,
+        authors: {
+          connectOrCreate: book.authors.map((name) => ({
+            where: { name },
+            create: { name },
+          })),
+        },
+      },
+      include: { authors: true },
+    });
+    res.status(201).json(formatBook(created));
+  } catch (e) {
+    res.status(500).json({
+      code: 'INTERNAL',
+      message: 'Failed to add book',
+      details: e instanceof Error ? e.message : e,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const books = await prisma.book.findMany({ include: { authors: true } });
+    res.json(books.map(formatBook));
+  } catch (e) {
+    res.status(500).json({
+      code: 'INTERNAL',
+      message: 'Failed to read books',
+      details: e instanceof Error ? e.message : e,
+    });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  const idParse = BookIdSchema.safeParse(req.params);
+  if (!idParse.success) {
+    return res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'Invalid id',
+      details: idParse.error.flatten(),
+    });
+  }
+  const parse = BookSchema.safeParse(req.body);
+  if (!parse.success) {
+    return res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'Invalid book',
+      details: parse.error.flatten(),
+    });
+  }
+  const book = parse.data;
+  const { id } = idParse.data;
+  try {
+    const updated = await prisma.book.update({
+      where: { id },
+      data: {
+        title: book.title,
+        authors: {
+          set: [],
+          connectOrCreate: book.authors.map((name) => ({
+            where: { name },
+            create: { name },
+          })),
+        },
+      },
+      include: { authors: true },
+    });
+    res.json(formatBook(updated));
+  } catch (e) {
+    res.status(500).json({
+      code: 'INTERNAL',
+      message: 'Failed to update book',
+      details: e instanceof Error ? e.message : e,
+    });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  const idParse = BookIdSchema.safeParse(req.params);
+  if (!idParse.success) {
+    return res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'Invalid id',
+      details: idParse.error.flatten(),
+    });
+  }
+  const { id } = idParse.data;
+  try {
+    const removed = await prisma.book.delete({
+      where: { id },
+      include: { authors: true },
+    });
+    res.json(formatBook(removed));
+  } catch (e) {
+    res.status(500).json({
+      code: 'INTERNAL',
+      message: 'Failed to delete book',
+      details: e instanceof Error ? e.message : e,
+    });
+  }
+});
+
+export default router;

--- a/server/routes/google-books.ts
+++ b/server/routes/google-books.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+import { GoogleBooksQuerySchema } from '../schemas';
+
+const router = Router();
+
+const gbCache = new Map<string, { ts: number; data: any }>();
+const CACHE_MS = 1000 * 60 * 60; // 1 hour
+
+router.get('/', async (req, res) => {
+  const parse = GoogleBooksQuerySchema.safeParse(req.query);
+  if (!parse.success) {
+    return res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'Invalid query',
+      details: parse.error.flatten(),
+    });
+  }
+  const { q } = parse.data;
+  const cached = gbCache.get(q);
+  if (cached && Date.now() - cached.ts < CACHE_MS) {
+    return res.json(cached.data);
+  }
+  const url = new URL('https://www.googleapis.com/books/v1/volumes');
+  url.searchParams.set('q', q);
+  url.searchParams.set('maxResults', '20');
+  const key = process.env.GOOGLE_BOOKS_KEY;
+  if (key) url.searchParams.set('key', key);
+  try {
+    const r = await fetch(url);
+    if (!r.ok) {
+      return res.status(500).json({
+        code: 'INTERNAL',
+        message: 'Failed to fetch',
+        details: r.statusText,
+      });
+    }
+    const data = await r.json();
+    gbCache.set(q, { ts: Date.now(), data });
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({
+      code: 'INTERNAL',
+      message: 'Failed to fetch',
+      details: e instanceof Error ? e.message : e,
+    });
+  }
+});
+
+export default router;

--- a/server/schemas.ts
+++ b/server/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const BookSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  authors: z.array(z.string()),
+});
+export type Book = z.infer<typeof BookSchema>;
+
+export const BookIdSchema = z.object({
+  id: z.string(),
+});
+
+export const GoogleBooksQuerySchema = z.object({
+  q: z.string().trim().min(1),
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
     });
     async function loadBooks(retries = 3): Promise<void> {
       try {
-        const res = await fetch('/api/books');
+        const res = await fetch('/api/v1/books');
         if (!res.ok) throw new Error('Network response was not ok');
         const serverBooks: Book[] = await res.json();
         for (const book of serverBooks) {
@@ -49,7 +49,10 @@ export default function App() {
     return () => sub.unsubscribe();
   }, []);
 
-  const filteredBooks = React.useMemo(() => selectFiltered(books, filter), [books, filter]);
+  const filteredBooks = React.useMemo(
+    () => selectFiltered(books, filter),
+    [books, filter],
+  );
 
   return (
     <div>
@@ -61,4 +64,3 @@ export default function App() {
     </div>
   );
 }
-

--- a/src/components/AddBookModal.tsx
+++ b/src/components/AddBookModal.tsx
@@ -79,7 +79,7 @@ export async function addBookOptimistically(b: Partial<Book>) {
     ...(b.external !== undefined ? { external: b.external } : {}),
   };
   await db.books.add(book);
-  await sendOrQueue('/api/books', {
+  await sendOrQueue('/api/v1/books', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(book),

--- a/src/db.ts
+++ b/src/db.ts
@@ -59,7 +59,7 @@ window.addEventListener('online', syncPendingRequests);
 
 export async function updateBook(book: Book) {
   await db.books.put(book);
-  await sendOrQueue(`/api/books/${book.id}`, {
+  await sendOrQueue(`/api/v1/books/${book.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(book),
@@ -68,5 +68,5 @@ export async function updateBook(book: Book) {
 
 export async function deleteBook(id: string) {
   await db.books.delete(id);
-  await sendOrQueue(`/api/books/${id}`, { method: 'DELETE' });
+  await sendOrQueue(`/api/v1/books/${id}`, { method: 'DELETE' });
 }

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -8,9 +8,12 @@ jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn() }));
 describe('useDebounce', () => {
   jest.useFakeTimers();
   test('debounces updates', () => {
-    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
-      initialProps: { value: 'a' },
-    });
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 500),
+      {
+        initialProps: { value: 'a' },
+      },
+    );
     expect(result.current).toBe('a');
     rerender({ value: 'b' });
     expect(result.current).toBe('a');
@@ -47,7 +50,7 @@ describe('searchGoogleBooks', () => {
     // @ts-ignore
     global.fetch = fetchMock;
     const res = await searchGoogleBooks('foo bar');
-    expect(fetchMock).toHaveBeenCalledWith('/api/google-books?q=foo%20bar');
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/google-books?q=foo%20bar');
     expect(res[0]!).toMatchObject({
       title: 'Test',
       authors: ['Ann'],

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -29,20 +29,20 @@ const GoogleBooksResponse = z.object({
           categories: z.array(z.string()).optional(),
           imageLinks: z.object({ thumbnail: z.string().optional() }).optional(),
         }),
-      })
+      }),
     )
     .optional(),
 });
 
 export async function searchGoogleBooks(q: string) {
-  const res = await fetch(`/api/google-books?q=${encodeURIComponent(q)}`);
+  const res = await fetch(`/api/v1/google-books?q=${encodeURIComponent(q)}`);
   if (!res.ok) throw new Error('Failed');
   const json = await res.json();
   const data = GoogleBooksResponse.parse(json);
   return (
     data.items?.map((v) => {
       const isbn13 = v.volumeInfo.industryIdentifiers?.find((i) =>
-        i.type.includes('ISBN_13')
+        i.type.includes('ISBN_13'),
       )?.identifier;
       const external: Book['external'] = { googleId: v.id };
       if (isbn13) external.isbn13 = isbn13;
@@ -55,7 +55,8 @@ export async function searchGoogleBooks(q: string) {
       };
       const year = v.volumeInfo.publishedDate?.slice(0, 4);
       if (year) book.year = Number(year);
-      if (v.volumeInfo.pageCount !== undefined) book.pages = v.volumeInfo.pageCount;
+      if (v.volumeInfo.pageCount !== undefined)
+        book.pages = v.volumeInfo.pageCount;
       if (v.volumeInfo.language) book.language = v.volumeInfo.language;
       const cover = v.volumeInfo.imageLinks?.thumbnail;
       if (cover) book.cover = cover;


### PR DESCRIPTION
## Summary
- scope API under `/api/v1` and move logic into dedicated routers
- centralize request/response validation with shared Zod schemas
- adjust frontend calls and tests to use versioned endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a49aa97b808328baade722b8309a34